### PR TITLE
Practica_8-1 al 10 modificado

### DIFF
--- a/Practica_8-01.X/main.asm
+++ b/Practica_8-01.X/main.asm
@@ -5,7 +5,7 @@ LIST P=16F877A
 __CONFIG _FOSC_HS & _WDTE_OFF & _PWRTE_OFF & _BOREN_OFF & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 ; Configuracion para el entrenador en fisico
-; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_ON & _CPD_OFF & _WRT_OFF & _CP_OFF
+; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
     
 CONST EQU b'00001101'		    ; Constante CONST es igual a 13
 
@@ -17,6 +17,8 @@ SETUP				    ; Etiqueta SETUP
     MOVLW   b'00011111'
     MOVWF   TRISD		    ; Los ultimos 5 pines del puerto D son de entrada
     BCF	    STATUS,	RP0	    ; Cambiar al Banco 0
+    CLRF    PORTB
+    CLRF    PORTD
 
 LOOP				    ; Etiqueta LOOP
     MOVF    PORTD,	0	    ; Leer los pines del puerto D y mover el resultado al registro W

--- a/Practica_8-02.X/main.asm
+++ b/Practica_8-02.X/main.asm
@@ -5,7 +5,7 @@ LIST P=16F877A
 __CONFIG _FOSC_HS & _WDTE_OFF & _PWRTE_OFF & _BOREN_OFF & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 ; Configuracion para el entrenador en fisico
-; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_ON & _CPD_OFF & _WRT_OFF & _CP_OFF
+; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
     ORG 0			    ; Indica el inicio del programa
 
@@ -15,6 +15,8 @@ SETUP				    ; Etiqueta SETUP
     MOVLW   b'00011111'
     MOVWF   TRISD		    ; Los ultimos 5 pines del puerto D son de entrada
     BCF	    STATUS,	RP0	    ; Cambiar al Banco 0
+    CLRF    PORTB
+    CLRF    PORTD
 
 LOOP				    ; Etiqueta LOOP
     MOVF    PORTD,	0	    ; Leer los pines del puerto D y moverlos al registro W

--- a/Practica_8-03.X/main.asm
+++ b/Practica_8-03.X/main.asm
@@ -5,7 +5,7 @@ LIST P=16F877A
 __CONFIG _FOSC_HS & _WDTE_OFF & _PWRTE_OFF & _BOREN_OFF & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 ; Configuracion para el entrenador en fisico
-; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_ON & _CPD_OFF & _WRT_OFF & _CP_OFF
+; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 MASK EQU b'01010101'		    ; Mascara que consiste el encendido de los bits pares
 
@@ -17,6 +17,8 @@ SETUP
     MOVLW   b'00011111'
     MOVWF   TRISD		    ; Los ultimos 5 pines del puerto D son de entrada
     BCF	    STATUS,	RP0	    ; Cambiar al banco 0
+    CLRF    PORTB
+    CLRF    PORTD
 
 LOOP
     MOVF    PORTD,	0	    ; Leer los pines del puerto D y mover el resultado al registro W

--- a/Practica_8-04.X/main.asm
+++ b/Practica_8-04.X/main.asm
@@ -5,7 +5,7 @@ LIST P=16F877A
 __CONFIG _FOSC_HS & _WDTE_OFF & _PWRTE_OFF & _BOREN_OFF & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 ; Configuracion para el entrenador en fisico
-; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_ON & _CPD_OFF & _WRT_OFF & _CP_OFF   
+; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
     ORG 0			    ; Indica el inicio del programa
 
@@ -15,6 +15,8 @@ SETUP				    ; Etiqueta SETUP
     MOVLW   b'00011111'
     MOVWF   TRISD		    ; Los ultimos 5 pines del puerto D son de entrada
     BCF	    STATUS,	RP0	    ; Cambiar al Banco 0
+    CLRF    PORTB
+    CLRF    PORTD
 
 LOOP				    ; Etiqueta LOOP
     MOVF    PORTD,	0	    ; Leer los pines del puerto D y moverlos al registro W

--- a/Practica_8-05.X/main.asm
+++ b/Practica_8-05.X/main.asm
@@ -5,7 +5,7 @@ LIST P=16F877A
 __CONFIG _FOSC_HS & _WDTE_OFF & _PWRTE_OFF & _BOREN_OFF & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 ; Configuracion para el entrenador en fisico
-; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_ON & _CPD_OFF & _WRT_OFF & _CP_OFF
+; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 MASK EQU b'11111111'		    ; Mascara para invertir los bits con la operacion XOR
 
@@ -17,6 +17,8 @@ SETUP
     MOVLW   b'00011111'
     MOVWF   TRISD		    ; Los ultimos 5 pines del puerto D son de entrada
     BCF	    STATUS,	RP0	    ; Cambiar al banco 0
+    CLRF    PORTB
+    CLRF    PORTD
 
 LOOP
     MOVF    PORTD,	0	    ; Leer los pines del puerto D y mover el resultado al registro W

--- a/Practica_8-06.X/main.asm
+++ b/Practica_8-06.X/main.asm
@@ -5,7 +5,7 @@ LIST P=16F877A
 __CONFIG _FOSC_HS & _WDTE_OFF & _PWRTE_OFF & _BOREN_OFF & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 ; Configuracion para el entrenador en fisico
-; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_ON & _CPD_OFF & _WRT_OFF & _CP_OFF   
+; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF   
 
     ORG 0			    ; Indica el inicio del programa
 
@@ -15,6 +15,8 @@ SETUP				    ; Etiqueta SETUP
     MOVLW   b'00011111'
     MOVWF   TRISD		    ; Los ultimos 5 pines del puerto D son de entrada
     BCF	    STATUS,	RP0	    ; Cambiar al Banco 0
+    CLRF    PORTB
+    CLRF    PORTD
 
 LOOP				    ; Etiqueta LOOP
     SWAPF   PORTD, W		    ; Intercambia los nibbles del byte de PORTD y lo guarda en W

--- a/Practica_8-07.X/main.asm
+++ b/Practica_8-07.X/main.asm
@@ -5,7 +5,7 @@ LIST P=16F877A
 __CONFIG _FOSC_HS & _WDTE_OFF & _PWRTE_OFF & _BOREN_OFF & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 ; Configuracion para el entrenador en fisico
-; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_ON & _CPD_OFF & _WRT_OFF & _CP_OFF
+; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
     ORG 0
 
@@ -15,6 +15,8 @@ SETUP
     MOVLW   b'00011111'
     MOVWF   TRISD		    ; Los ultimos 5 pines del puerto D son de entrada
     BCF	    STATUS,	RP0	    ; Cambiar al banco 0
+    CLRF    PORTB
+    CLRF    PORTD
 
 LOOP
     RLF	    PORTD,	0	    ; Leer los pines del puerto D, rotar los bits una posicion a la izquierda y guardar el resultado al registro W

--- a/Practica_8-08.X/main.asm
+++ b/Practica_8-08.X/main.asm
@@ -5,7 +5,7 @@ LIST P=16F877A
 __CONFIG _FOSC_HS & _WDTE_OFF & _PWRTE_OFF & _BOREN_OFF & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 ; Configuracion para el entrenador en fisico
-; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_ON & _CPD_OFF & _WRT_OFF & _CP_OFF
+; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
     
 CONST EQU b'00000101'		    ; Constante CONST es igual a 13
 
@@ -17,6 +17,8 @@ SETUP				    ; Etiqueta SETUP
     MOVLW   b'00011111'
     MOVWF   TRISD		    ; Los ultimos 5 pines del puerto D son de entrada
     BCF	    STATUS,	RP0	    ; Cambiar al Banco 0
+    CLRF    PORTB
+    CLRF    PORTD
 
 LOOP				    ; Etiqueta LOOP
     RRF	    PORTD,	0	    ; Leer los pines del puerto D, rotar los bits una posicion a la izquierda y guardar el resultado al registro W

--- a/Practica_8-09.X/main.asm
+++ b/Practica_8-09.X/main.asm
@@ -5,7 +5,7 @@ LIST P=16F877A
 __CONFIG _FOSC_HS & _WDTE_OFF & _PWRTE_OFF & _BOREN_OFF & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 ; Configuracion para el entrenador en fisico
-; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_ON & _CPD_OFF & _WRT_OFF & _CP_OFF
+; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 MASK EQU b'01010101'		    ; Mascara para invertir los bits pares con la operacion XOR
 
@@ -17,6 +17,8 @@ SETUP
     MOVLW   b'00011111'
     MOVWF   TRISD		    ; Los ultimos 5 pines del puerto D son de entrada
     BCF	    STATUS,	RP0	    ; Cambiar al banco 0
+    CLRF    PORTB
+    CLRF    PORTD
 
 LOOP
     MOVF    PORTD,	0	    ; Leer los pines del puerto D y mover el resultado al registro W

--- a/Practica_8-10.X/main.asm
+++ b/Practica_8-10.X/main.asm
@@ -5,7 +5,7 @@ LIST P=16F877A
 __CONFIG _FOSC_HS & _WDTE_OFF & _PWRTE_OFF & _BOREN_OFF & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 ; Configuracion para el entrenador en fisico
-; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_ON & _CPD_OFF & _WRT_OFF & _CP_OFF    
+; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
     ORG 0			    ; Indica el inicio del programa
 
@@ -15,6 +15,8 @@ SETUP				    ; Etiqueta SETUP
     MOVLW   b'00011111'
     MOVWF   TRISD		    ; Los ultimos 5 pines del puerto D son de entrada
     BCF	    STATUS,	RP0	    ; Cambiar al Banco 0
+    CLRF    PORTB
+    CLRF    PORTD
 
 LOOP				    ; Etiqueta LOOP
     MOVF    PORTD,	0	    ; Leer los pines del puerto D y mover el resultado al registro W

--- a/PruebaSalidaPuertoB.X/main.asm
+++ b/PruebaSalidaPuertoB.X/main.asm
@@ -8,7 +8,7 @@ LIST P=16F877A
 __CONFIG _FOSC_HS & _WDTE_OFF & _PWRTE_OFF & _BOREN_OFF & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 ; Configuracion para el entrenador en fisico
-; __CONFIG _CP_OFF & _WDT_OFF & _PWRTE_ON & _XT_OSC
+; __CONFIG _FOSC_XT & _WDTE_OFF & _PWRTE_ON & _BOREN_ON & _LVP_OFF & _CPD_OFF & _WRT_OFF & _CP_OFF
 
 DELAY_COUNTER_1 EQU 0x20
 DELAY_COUNTER_2 EQU 0x21
@@ -20,6 +20,7 @@ SETUP
     BSF	    STATUS,     RP0
     CLRF    TRISB
     BCF	    STATUS,     RP0
+    CLRF    PORTB
     BSF	    PORTB,      0
 
 MAIN

--- a/PruebaSalidaPuertoB.X/nbproject/private/private.xml
+++ b/PruebaSalidaPuertoB.X/nbproject/private/private.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-private xmlns="http://www.netbeans.org/ns/project-private/1">
+    <editor-bookmarks xmlns="http://www.netbeans.org/ns/editor-bookmarks/2" lastBookmarkId="0"/>
+    <open-files xmlns="http://www.netbeans.org/ns/projectui-open-files/2">
+        <group name="programacion-microcontroladores">
+            <file>file:/C:/Git/programacion-microcontroladores/PruebaSalidaPuertoB.X/main.asm</file>
+        </group>
+    </open-files>
+</project-private>


### PR DESCRIPTION
- Se modifcaron los bits de configuración de las prácticas para que el PIC16F877A no trabaje en modo de programación de voltaje bajo: _LVP_OFF
- Se agregaron dos instrucciones adicionales que limpian los puertos de entrada y salida (PORTD y PORTB) al final de la fase de inicialización (SETUP)